### PR TITLE
feat(cli): add schema and type commands to CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,15 @@
  * This module contains the command line interface for the ghf cli.
  *
  */
+import { compile } from 'npm:json-schema-to-typescript'
 import data from '../deno.json' with { type: 'json' }
 import { getConfig } from './config.ts'
-import { Command } from './deps.ts'
-import { planRules } from './rules/index.ts'
-import { loadSettings } from './settings.ts'
+import { Command, z } from './deps.ts'
 import { applyPlans } from './plan.ts'
+import { planRules } from './rules/index.ts'
+import { loadSettings, settingsSchema } from './settings.ts'
+
+type JSONSchema4 = Parameters<typeof compile>[0]
 
 await new Command()
   .name('ghf')
@@ -24,5 +27,31 @@ await new Command()
     const settings = await loadSettings(config.config)
     const plans = await planRules(settings)
     await applyPlans(plans, { dryRun: config.dryRun })
+  })
+  .command('schema', 'returns the json schema for the ghf config file')
+  .option('-o, --outfile <outfile:string>', 'Outfile to write to (ie: .ghf.schema.json)', { default: '' })
+  .action(async ({ outfile }) => {
+    const schema = z.toJSONSchema(settingsSchema)
+    const json = JSON.stringify(schema, null, 2)
+
+    if (outfile) {
+      await Deno.writeTextFile(outfile, json)
+    } else {
+      // biome-ignore lint/suspicious/noConsoleLog: this output the schema to the console
+      console.log(json)
+    }
+  })
+  .command('type', 'returns the typescript type for the ghf config file')
+  .option('-o, --outfile <outfile:string>', 'Outfile to write to (ie: .ghf.type.ts)', { default: '' })
+  .action(async ({ outfile }) => {
+    const schema = z.toJSONSchema(settingsSchema)
+    const type = await compile(schema as unknown as JSONSchema4, 'Config')
+
+    if (outfile) {
+      await Deno.writeTextFile(outfile, type)
+    } else {
+      // biome-ignore lint/suspicious/noConsoleLog: this output the schema to the console
+      console.log(type)
+    }
   })
   .parse(Deno.args)

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
-export { Command, EnumType } from 'jsr:@cliffy/command@1.0.0-rc.4'
-export { z } from 'npm:zod@3.22.4'
+export { Command, EnumType } from 'jsr:@cliffy/command@1.0.0-rc.7'
+export { z } from 'npm:zod@3.25.62/v4'
 export { stringify as stringifyYaml, parse as parseYaml } from 'jsr:@std/yaml@0.221.0'
 export { exists } from 'jsr:@std/fs'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,19 +1,51 @@
+import * as esbuild from 'npm:esbuild@0.25.5'
+import { encodeBase64 } from 'jsr:@std/encoding/base64'
 import { parseYaml } from './deps.ts'
+
+function tseval(code: string) {
+  return import(`data:application/typescript;charset=utf-8;base64,${encodeBase64(code)}`)
+}
+
+const getFromJs = async (code: string) => {
+  const result = await tseval(code)
+  return result.default
+}
+
+const getFromTs = async (code: string) => {
+  const { outputFiles } = await esbuild.build({
+    stdin: { contents: code, loader: 'ts' },
+    outfile: undefined,
+    write: false,
+    format: 'esm',
+  })
+
+  const artifact = outputFiles[0]
+
+  if (!artifact) {
+    throw new Error('Failed to build ts file')
+  }
+
+  return getFromJs(artifact.text)
+}
 
 const parseFuncs = {
   yaml: parseYaml,
   yml: parseYaml,
   json: JSON.parse,
-} as const satisfies Record<string, (content: string) => unknown>
+  js: getFromJs,
+  ts: getFromTs,
+} as const satisfies Record<string, (content: string) => Promise<unknown> | unknown>
 
 type ContentType = keyof typeof parseFuncs
 
-export const parse = (content: string, type: string) => {
+export const parse = async (content: string, type: string) => {
   const parseFunc = parseFuncs[type as ContentType]
 
   if (!parseFunc) {
     throw new Error(`Unsupported content type: ${type}`)
   }
 
-  return parseFunc(content)
+  const parsed = await parseFunc(content)
+
+  return parsed
 }

--- a/src/rules/exec.ts
+++ b/src/rules/exec.ts
@@ -6,7 +6,7 @@ export const ruleExecSchema = z.object({
   cmd: z.string(),
   args: z.array(z.string()),
   cwd: z.string(),
-  env: z.record(z.string()),
+  env: z.record(z.string(), z.string()),
 })
 
 type RuleExec = z.infer<typeof ruleExecSchema>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ import { ruleSchema } from './rules/index.ts'
 
 export const settingsSchema = z.object({
   extends: z.string().array().optional(),
-  presets: z.record(ruleSchema.array()).default({}),
+  presets: z.record(z.string(), ruleSchema.array()).default({}),
   rules: ruleSchema.array(),
 })
 
@@ -17,7 +17,7 @@ export const loadSettings = async (filepath: string) => {
 
   const extension = filepath.split('.').pop()
 
-  const data = parse(content, extension ?? '')
+  const data = await parse(content, extension ?? '')
 
   const settings = settingsSchema.parse(data)
 


### PR DESCRIPTION
Add schema and type commands to CLI

This PR introduces two new CLI commands to expose the GHF config schema and TypeScript types:

- `ghf schema` - Returns the JSON schema for the config file
- `ghf type` - Returns the TypeScript type definition for the config file

## Overview of changes

- Added `schema` command that converts the settings schema to JSON Schema format with an optional file output
- Added `type` command that generates TypeScript types from the schema using json-schema-to-typescript
- Updated dependencies:
  - Upgraded Cliffy command from 1.0.0-rc.4 to 1.0.0-rc.7
  - Upgraded Zod from 3.22.4 to 3.25.62/v4
- Enhanced the parse module to support JavaScript and TypeScript config files
- Fixed a type issue in the exec rule schema to properly specify the record type
- Improved the settings schema to better type the presets record

These new commands will help users create properly typed config files and enable better IDE integration through JSON schema validation.