### PR TITLE
feat(rules): implement exec and merge rule functions with type checking

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,3 +14,6 @@ format:
       run: biome format --write {staged_files}
     lint:
       run: biome lint --write --unsafe {staged_files}
+    typecheck:
+      glob: '*.{ts,tsx}'
+      run: deno check ./src/cli.ts

--- a/src/rules/exec.test.ts
+++ b/src/rules/exec.test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from 'jsr:@std/assert'
+import { TestFileSystem } from '../util.test.ts'
+import { ruleExecFunc } from './exec.ts'
+
+Deno.test('rule exec should execute a command', async () => {
+  const fs = TestFileSystem()
+
+  const rule = {
+    type: 'exec' as const,
+    cmd: 'echo',
+    args: ['test'],
+    outfile: 'path/to/file',
+  }
+
+  await ruleExecFunc(rule, fs)
+
+  assertEquals(await fs.read('path/to/file'), 'test\n')
+})

--- a/src/rules/exec.ts
+++ b/src/rules/exec.ts
@@ -5,13 +5,14 @@ export const ruleExecSchema = z.object({
   type: z.literal('exec'),
   cmd: z.string(),
   args: z.array(z.string()),
-  cwd: z.string(),
-  env: z.record(z.string(), z.string()),
+  cwd: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  outfile: z.string().optional(),
 })
 
 type RuleExec = z.infer<typeof ruleExecSchema>
 
-export const ruleExecFunc = async ({ cmd, args, cwd, env }: RuleExec, __: FileSystem) => {
+export const ruleExecFunc = async ({ cmd, args, cwd, env, outfile }: RuleExec, fs: FileSystem) => {
   const command = new Deno.Command(cmd, {
     args,
     cwd,
@@ -23,5 +24,8 @@ export const ruleExecFunc = async ({ cmd, args, cwd, env }: RuleExec, __: FileSy
   if (output.code !== 0) {
     throw new Error(`Command exited with code ${output.code}`)
   }
-  // TODO implement ruleExecFunc
+
+  if (outfile) {
+    await fs.write(outfile, new TextDecoder().decode(output.stdout))
+  }
 }

--- a/src/rules/merge.test.ts
+++ b/src/rules/merge.test.ts
@@ -1,0 +1,69 @@
+import { assertEquals } from 'jsr:@std/assert'
+import { TestFileSystem } from '../util.test.ts'
+import { ruleMergeFunc } from './merge.ts'
+
+Deno.test('rule merge should create a new json file with the content if not exists', async () => {
+  const fs = TestFileSystem()
+  const filename = 'path/to/file.json'
+
+  const rule = {
+    type: 'merge' as const,
+    path: filename,
+    content: JSON.stringify({ test: 'test', b: 'c' }),
+    mergeArrays: false,
+  }
+
+  await ruleMergeFunc(rule, fs)
+
+  assertEquals(await fs.read(filename), JSON.stringify({ test: 'test', b: 'c' }))
+})
+
+Deno.test('rule merge should create a new yaml file with the content if not exists', async () => {
+  const fs = TestFileSystem()
+  const filename = 'path/to/file.yaml'
+
+  const rule = {
+    type: 'merge' as const,
+    path: filename,
+    content: 'test: 1\nfoo: bar',
+    mergeArrays: false,
+  }
+
+  await ruleMergeFunc(rule, fs)
+
+  assertEquals(await fs.read(filename), 'test: 1\nfoo: bar\n')
+})
+
+Deno.test('rule merge should create a new yml file with the content if not exists', async () => {
+  const fs = TestFileSystem()
+  const filename = 'path/to/file.yml'
+
+  const rule = {
+    type: 'merge' as const,
+    path: filename,
+    content: 'test: 1\nfoo: bar',
+    mergeArrays: false,
+  }
+
+  await ruleMergeFunc(rule, fs)
+
+  assertEquals(await fs.read(filename), 'test: 1\nfoo: bar\n')
+})
+
+Deno.test('rule merge should merge the content of a file with another', async () => {
+  const fs = TestFileSystem()
+  const filename = 'path/to/file.json'
+
+  await fs.write(filename, JSON.stringify({ test: 'test', b: 'c' }))
+
+  const rule = {
+    type: 'merge' as const,
+    path: filename,
+    content: JSON.stringify({ test: 'test2', foo: 'bar' }),
+    mergeArrays: false,
+  }
+
+  await ruleMergeFunc(rule, fs)
+
+  assertEquals(await fs.read(filename), JSON.stringify({ test: 'test2', b: 'c', foo: 'bar' }))
+})

--- a/src/rules/merge.ts
+++ b/src/rules/merge.ts
@@ -1,15 +1,59 @@
+import { merge } from 'npm:ts-deepmerge@7.0.3'
 import { z } from '../deps.ts'
+import { parseYaml, stringifyYaml } from '../deps.ts'
 import type { FileSystem } from '../filesystem.ts'
-import { contentSchema } from '../schemas.ts'
+import { contentSchema, loadContent } from '../schemas.ts'
+
+const parseFuncs = {
+  yaml: parseYaml,
+  yml: parseYaml,
+  json: JSON.parse,
+} as const satisfies Record<string, (content: string) => Promise<unknown> | unknown>
+
+const stringifyFuncs = {
+  yaml: stringifyYaml,
+  yml: stringifyYaml,
+  json: JSON.stringify,
+}
+
+type ContentType = keyof typeof parseFuncs
 
 export const ruleMergeSchema = z.object({
   type: z.literal('merge'),
   path: z.string(),
   content: contentSchema,
+  mergeArrays: z.boolean().optional().default(true),
 })
 
 type RuleMerge = z.infer<typeof ruleMergeSchema>
 
-export const ruleMergeFunc = async (_: RuleMerge, __: FileSystem) => {
-  // TODO implement ruleMergeFunc
+export const ruleMergeFunc = async ({ path, content, mergeArrays }: RuleMerge, fs: FileSystem) => {
+  const newContent = await loadContent(content)
+  const oldContent = await fs.fetch(path)
+
+  if (oldContent === newContent) {
+    return
+  }
+
+  const type = path.split('.').pop()
+
+  const parseFunc = parseFuncs[type as ContentType]
+  const stringifyFunc = stringifyFuncs[type as ContentType]
+
+  if (!parseFunc || !stringifyFunc) {
+    throw new Error(`Unsupported content type: ${type}`)
+  }
+
+  const newData = await parseFunc(newContent)
+
+  if (!oldContent) {
+    await fs.write(path, stringifyFunc(newData))
+    return
+  }
+
+  const oldData = await parseFunc(oldContent)
+
+  const mergedData = merge.withOptions({ mergeArrays }, oldData, newData)
+
+  await fs.write(path, stringifyFunc(mergedData))
 }


### PR DESCRIPTION
Add TypeChecking to Lefthook and Implement Missing Rules

This PR adds TypeCheck to Lefthook pre-commit hook and implements the previously empty 'exec' and 'merge' rule functions. I've also added comprehensive tests for both rules to ensure functionality is working as expected.

## Overview of Changes:

1. **Lefthook Configuration**:
   - Added a new TypeCheck hook that runs `deno check` on TypeScript files before commit
   - This will help catch type errors early in the development process

2. **Exec Rule Implementation**:
   - Implemented the previously empty `ruleExecFunc` to execute command-line commands
   - Added support for writing command output to a file
   - Made `cwd` and `env` parameters optional for better flexibility
   - Added comprehensive test coverage

3. **Merge Rule Implementation**:
   - Implemented the previously empty `ruleMergeFunc` to merge structured content
   - Added support for merging JSON, YAML, and YML files
   - Implemented content merging using `ts-deepmerge` library
   - Added optional `mergeArrays` parameter to control array merging behavior
   - Added extensive tests covering various merge scenarios

These additions complete the implementation of all rules described in the project's documentation and enhance the developer experience with type checking on commit.