### PR TITLE
chore(deps): pin dependency versions for stability

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@
  * This module contains the command line interface for the ghf cli.
  *
  */
-import { compile } from 'npm:json-schema-to-typescript'
+import { compile } from 'npm:json-schema-to-typescript@15.0.4'
 import data from '../deno.json' with { type: 'json' }
 import { getConfig } from './config.ts'
 import { Command, z } from './deps.ts'

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
 export { Command, EnumType } from 'jsr:@cliffy/command@1.0.0-rc.7'
 export { z } from 'npm:zod@3.25.62/v4'
 export { stringify as stringifyYaml, parse as parseYaml } from 'jsr:@std/yaml@0.221.0'
-export { exists } from 'jsr:@std/fs'
+export { exists } from 'jsr:@std/fs@1.0.18'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import * as esbuild from 'npm:esbuild@0.25.5'
-import { encodeBase64 } from 'jsr:@std/encoding/base64'
+import { encodeBase64 } from 'jsr:@std/encoding@1.0.10/base64'
 import { parseYaml } from './deps.ts'
 
 function tseval(code: string) {


### PR DESCRIPTION
This pull request pins dependency versions to ensure stability and compatibility.

The changes include:

- Pinned `json-schema-to-typescript` to version 15.0.4
- Pinned `@std/fs` to version 1.0.18
- Pinned `@std/encoding` to version 1.0.10 for the base64 module
