### PR TITLE
chore(ghf): refactor extend handling for remote configs to use normalizeUrl 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .vscode
 extension_tiltfile
 .env
+node_modules
+dist

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelmass/ghf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lock": false,
   "exports": {
     "./cli": "./src/cli.ts"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -61,7 +61,7 @@ const setupRemoteRules = (settings: Settings, remote: string) => {
     }
   }
 
-  settings.extends = settings.extends?.map(extend => (extend.startsWith('https://') ? extend : getContentValue(replacePathWithRemote(extend, remote)))) ?? []
+  settings.extends = settings.extends?.map(extend => (extend.startsWith('https://') ? extend : normalizeUrl(`${remote}/${extend}`))) ?? []
 }
 
 const updateRuleWithRemote = (rule: Rule, remote: string) => {
@@ -79,22 +79,6 @@ const updateRuleWithRemote = (rule: Rule, remote: string) => {
       rule.content = replacePathWithRemote(rule.content, remote)
       break
   }
-}
-
-const getContentValue = (content: Content): string => {
-  if (typeof content === 'string') {
-    return content
-  }
-
-  if ('url' in content) {
-    return content.url
-  }
-
-  if ('path' in content) {
-    return content.path
-  }
-
-  throw new Error('Unsupported content type')
 }
 
 const replacePathWithRemote = (content: Content, remote: string): Content => {


### PR DESCRIPTION
This PR updates the `.gitignore` file, bumps the package version, and refactors URL handling in the settings module.

## Overview of Changes:

1. **`.gitignore` Updates**:
   - Added `node_modules` and `dist` to the ignored files
   - These are standard exclusions for JavaScript/TypeScript projects

2. **Version Bump**:
   - Updated package version from `0.1.0` to `0.1.1` in `deno.json`

3. **Code Refactoring**:
   - Replaced `getContentValue(replacePathWithRemote(extend, remote))` with `normalizeUrl(`${remote}/${extend}`)`