### PR TITLE
feat(ghf): add part rule and update registry configurations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelmass/ghf",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lock": false,
   "exports": {
     "./cli": "./src/cli.ts"

--- a/registry/.gitignore
+++ b/registry/.gitignore
@@ -4,3 +4,4 @@
 extension_tiltfile
 node_modules
 dist
+.ghf.type.ts

--- a/registry/LICENSE-MIT
+++ b/registry/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2024 Michael Masson <contact@michaelmasson.com>
+Copyright (c) 2020-2025 Michael Masson <contact@michaelmasson.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/registry/ghf.default.json
+++ b/registry/ghf.default.json
@@ -4,11 +4,16 @@
   "rules": [
     {
       "type": "preset",
-      "name": "liscense-mit"
+      "name": "gitignore"
     },
     {
       "type": "preset",
-      "name": "gitignore"
+      "name": "tiltfile-init"
+    },
+    {
+      "type": "init",
+      "path": "lefthook.yml",
+      "content": ""
     }
   ]
 }

--- a/registry/ghf.json
+++ b/registry/ghf.json
@@ -6,7 +6,7 @@
         "type": "file",
         "path": "LICENSE",
         "content": {
-          "path": "LICENSE"
+          "path": "LICENSE-MIT"
         }
       }
     ],
@@ -16,6 +16,15 @@
         "path": ".gitignore",
         "content": {
           "path": ".gitignore"
+        }
+      }
+    ],
+    "tiltfile-init": [
+      {
+        "type": "part",
+        "path": "Tiltfile",
+        "content": {
+          "url": "https://raw.githubusercontent.com/michaelmass/tiltfile-extensions/master/default.Tiltfile"
         }
       }
     ]

--- a/src/rules/part.test.ts
+++ b/src/rules/part.test.ts
@@ -1,0 +1,162 @@
+import { assertEquals } from 'jsr:@std/assert'
+import { TestFileSystem } from '../util.test.ts'
+import { rulePartFunc } from './part.ts'
+
+Deno.test('rule part with strategy content should create a file if it does not exist', async () => {
+  const fs = TestFileSystem()
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'content',
+  } as const
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), rule.content)
+})
+
+Deno.test('rule part with strategy start should create a file if it does not exist', async () => {
+  const fs = TestFileSystem()
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'start',
+  } as const
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), rule.content)
+})
+
+Deno.test('rule part with strategy end should create a file if it does not exist', async () => {
+  const fs = TestFileSystem()
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'end',
+  } as const
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), rule.content)
+})
+
+Deno.test('rule part with strategy start should add a part to the start of the file', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'old_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'start',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), `${rule.content}${oldContent}`)
+})
+
+Deno.test('rule part with strategy end should add a part to the end of the file', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'old_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'end',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), `${oldContent}${rule.content}`)
+})
+
+Deno.test('rule part with strategy content should add a part to the end of the file', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'old_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'content',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), `${oldContent}${rule.content}`)
+})
+
+Deno.test('rule part with strategy start should do nothing if the file already contains the part', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'random_content old_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'start',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), oldContent)
+})
+
+Deno.test('rule part with strategy end should do nothing if the file already contains the part', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'old_content random_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'end',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), oldContent)
+})
+
+Deno.test('rule part with strategy content should do nothing if the file already contains the part', async () => {
+  const fs = TestFileSystem()
+
+  const oldContent = 'old_content random_content old_content'
+
+  const rule = {
+    type: 'part',
+    content: 'random_content',
+    path: 'path/to/part',
+    strategy: 'content',
+  } as const
+
+  await fs.write(rule.path, oldContent)
+
+  await rulePartFunc(rule, fs)
+
+  assertEquals(await fs.read(rule.path), oldContent)
+})

--- a/src/rules/part.ts
+++ b/src/rules/part.ts
@@ -1,0 +1,43 @@
+import { z } from '../deps.ts'
+import type { FileSystem } from '../filesystem.ts'
+import { contentSchema, loadContent } from '../schemas.ts'
+
+const strategyFormatFuncs = {
+  start: (oldContent: string, newContent: string) => `${newContent}${oldContent}`,
+  end: (oldContent: string, newContent: string) => `${oldContent}${newContent}`,
+  content: (oldContent: string, newContent: string) => `${oldContent}${newContent}`,
+}
+
+const strategyCompareFuncs = {
+  start: (oldContent: string, newContent: string) => oldContent.startsWith(newContent),
+  end: (oldContent: string, newContent: string) => oldContent.endsWith(newContent),
+  content: (oldContent: string, newContent: string) => oldContent.includes(newContent),
+}
+
+export const rulePartSchema = z.object({
+  type: z.literal('part'),
+  path: z.string(),
+  content: contentSchema,
+  strategy: z.enum(['start', 'end', 'content']).optional().default('content'),
+})
+
+type RulePart = z.infer<typeof rulePartSchema>
+
+export const rulePartFunc = async ({ content, path, strategy }: RulePart, fs: FileSystem) => {
+  const newContent = await loadContent(content)
+
+  const oldContent = await fs.fetch(path)
+
+  const compareFunc = strategyCompareFuncs[strategy]
+  const formatFunc = strategyFormatFuncs[strategy]
+
+  if (!compareFunc || !formatFunc) {
+    throw new Error(`Unsupported strategy: ${strategy}`)
+  }
+
+  if (compareFunc(oldContent ?? '', newContent)) {
+    return
+  }
+
+  await fs.write(path, formatFunc(oldContent ?? '', newContent))
+}

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -7,6 +7,7 @@ import { ruleFileFunc, ruleFileSchema } from './file.ts'
 import { ruleInitFunc, ruleInitSchema } from './init.ts'
 import { ruleLinesFunc, ruleLinesSchema } from './lines.ts'
 import { ruleMergeFunc, ruleMergeSchema } from './merge.ts'
+import { rulePartFunc, rulePartSchema } from './part.ts'
 import { ruleResetFunc, ruleResetSchema } from './reset.ts'
 
 const rulePresetSchema = z.object({
@@ -32,7 +33,7 @@ const rulePresetFunc = async ({ name }: PresetRule, fs: FileSystem, settings: Se
   }
 }
 
-export const ruleSchema = z.discriminatedUnion('type', [ruleFileSchema, rulePresetSchema, ruleLinesSchema, ruleResetSchema, ruleDeleteSchema, ruleInitSchema, ruleMergeSchema])
+export const ruleSchema = z.discriminatedUnion('type', [ruleFileSchema, rulePresetSchema, ruleLinesSchema, ruleResetSchema, ruleDeleteSchema, ruleInitSchema, ruleMergeSchema, rulePartSchema])
 
 export type Rule = z.infer<typeof ruleSchema>
 type RuleType = Rule['type']
@@ -47,6 +48,7 @@ const ruleFuncs = {
   preset: rulePresetFunc,
   init: ruleInitFunc,
   merge: ruleMergeFunc,
+  part: rulePartFunc,
 } satisfies { [key in RuleType]: RuleFunc<key> }
 
 export const planRules = async (settings: Settings): Promise<Plan[]> => {


### PR DESCRIPTION
Version Bump to 0.1.2 and Add New Features

This PR bumps the package version from 0.1.1 to 0.1.2 and introduces several improvements to the project.

## Overview of Changes:

1. **New 'Part' Rule Implementation**:
   - Added new functionality to insert content at specific positions in files
   - Implemented three strategies: 'start', 'end', and 'content' for flexible content insertion
   - Added comprehensive test coverage for the new rule

2. **Registry Updates**:
   - Renamed LICENSE to LICENSE-MIT for clarity
   - Updated copyright years from 2024 to 2025
   - Added `.ghf.type.ts` to gitignore
   - Added 'tiltfile-init' preset in registry configurations
   - Added lefthook.yml initialization in default configuration

This update expands the tool's flexibility by allowing partial content insertions in files while maintaining the existing behavior for files that already contain the content.