### PR TITLE
feat(registry): add 'part' type to schema for partial file operations

### DIFF
--- a/registry/schema.json
+++ b/registry/schema.json
@@ -256,6 +256,61 @@
                 "path",
                 "content"
               ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "part"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "content": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "path"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url"
+                      ]
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "strategy": {
+                  "default": "content",
+                  "type": "string",
+                  "enum": [
+                    "start",
+                    "end",
+                    "content"
+                  ]
+                }
+              },
+              "required": [
+                "type",
+                "path",
+                "content"
+              ]
             }
           ]
         }
@@ -492,6 +547,61 @@
                   {
                     "type": "string"
                   }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "path",
+              "content"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "part"
+              },
+              "path": {
+                "type": "string"
+              },
+              "content": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "url": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ]
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "strategy": {
+                "default": "content",
+                "type": "string",
+                "enum": [
+                  "start",
+                  "end",
+                  "content"
                 ]
               }
             },


### PR DESCRIPTION
Added 'part' Type to Schema for Partial File Operations

This PR introduces a new 'part' type in the schema.json file to support partial file operations. This enhancement allows for more granular modifications to files, inserting content at the start, end, or replacing specific parts.
