### PR TITLE
feat(plan): make `old` property optional in UpdatePlan type

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelmass/ghf",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lock": false,
   "exports": {
     "./cli": "./src/cli.ts"

--- a/src/plan.ts
+++ b/src/plan.ts
@@ -7,7 +7,7 @@ type CreatePlan = {
 type UpdatePlan = {
   type: 'update'
   path: string
-  old: string
+  old?: string
   new: string
 }
 

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -71,7 +71,7 @@ export const planRules = async (settings: Settings): Promise<Plan[]> => {
       plans.push({ type: 'create', path, content })
     }
 
-    const old = await Deno.readTextFile(path)
+    const old = await Deno.readTextFile(path).catch(() => undefined)
 
     if (old !== content) {
       plans.push({ type: 'update', path, old, new: content })


### PR DESCRIPTION
This pull request updates the `UpdatePlan` type in `plan.ts` to make the `old` property optional and modifies how file content is read in the `planRules` function. The version number in `deno.json` has been incremented from 0.1.2 to 0.1.3.

## Overview of Changes

- Made the `old` property in the `UpdatePlan` type optional by adding a `?` to its type definition
- Updated the file reading logic in `planRules` to gracefully handle cases where the file doesn't exist by adding a `.catch(() => undefined)` to the `Deno.readTextFile` call
- Bumped the version number from 0.1.2 to 0.1.3 in deno.json to reflect these changes

This change improves error handling when working with files that don't yet exist, allowing the tool to operate more robustly during file update operations.