### PR TITLE
chore(package): bump version and improve presets handling

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelmass/ghf",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lock": false,
   "exports": {
     "./cli": "./src/cli.ts"

--- a/registry/schema.json
+++ b/registry/schema.json
@@ -12,7 +12,6 @@
       }
     },
     "presets": {
-      "default": {},
       "type": "object",
       "propertyNames": {
         "type": "string"

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -18,7 +18,7 @@ const rulePresetSchema = z.object({
 type PresetRule = z.infer<typeof rulePresetSchema>
 
 const rulePresetFunc = async ({ name }: PresetRule, fs: FileSystem, settings: Settings) => {
-  const preset = settings.presets[name]
+  const preset = settings.presets?.[name]
 
   if (!preset) {
     throw new Error(`Preset not found: ${name}`)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ import { normalizeUrl } from './url.ts'
 export const settingsSchema = z.object({
   $schema: z.string().optional(),
   extends: z.string().array().optional(),
-  presets: z.record(z.string(), ruleSchema.array()).optional().default({}),
+  presets: z.record(z.string(), ruleSchema.array()).optional(),
   rules: ruleSchema.array().optional(),
 })
 
@@ -24,7 +24,7 @@ export const loadSettings = async (filepath: string) => {
 
   const settings = settingsSchema.parse(data)
 
-  const presetEntries = Object.entries(settings.presets)
+  const presetEntries = Object.entries(settings.presets ?? {})
 
   for (const [_, rules] of presetEntries) {
     for (const rule of rules) {
@@ -55,7 +55,7 @@ const setupRemoteRules = (settings: Settings, remote: string) => {
     updateRuleWithRemote(rule, remote)
   }
 
-  for (const preset of Object.values(settings.presets)) {
+  for (const preset of Object.values(settings.presets ?? {})) {
     for (const rule of preset) {
       updateRuleWithRemote(rule, remote)
     }


### PR DESCRIPTION
This PR updates the handling of presets in the settings schema and related code. It also increments the package version from 0.1.3 to 0.1.4.

## Overview of changes:

1. Package version bump:
   - Updated version in `deno.json` from 0.1.3 to 0.1.4

2. Schema improvements:
   - Removed the default empty object for presets in the registry schema
   - This allows presets to be properly optional

3. Code refactoring for better null handling:
   - Updated `rulePresetFunc` to safely access preset using optional chaining
   - Modified `settings.ts` to handle cases where presets might be undefined:
     - Updated the schema definition to remove the default empty object
     - Added null coalescing when accessing presets in various functions

These changes make the handling of presets more robust by properly making them optional rather than defaulting to an empty object, addressing potential issues when presets are not defined in the configuration.