### PR TITLE
feat(cli): add settings and init commands with version bump to 0.1.5

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@michaelmass/ghf",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lock": false,
   "exports": {
     "./cli": "./src/cli.ts"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,10 +13,22 @@ export const settingsSchema = z.object({
 
 export type Settings = z.infer<typeof settingsSchema>
 
+const findSettingsFile = () => {
+  const files = ['.ghf.ts', 'ghf.ts', '.ghf.json', 'ghf.json', '.ghf.js', 'ghf.js', '.ghf.yaml', 'ghf.yaml', '.ghf.yml', 'ghf.yml']
+
+  for (const file of files) {
+    if (Deno.statSync(file).isFile) {
+      return file
+    }
+  }
+
+  throw new Error('No settings file found')
+}
+
 export const loadSettings = async (filepath: string) => {
   const isRemote = filepath.startsWith('https://')
 
-  const content = isRemote ? await (await fetch(filepath)).text() : await Deno.readTextFile(filepath)
+  const content = isRemote ? await (await fetch(filepath)).text() : await Deno.readTextFile(filepath === '' ? findSettingsFile() : filepath)
 
   const extension = filepath.split('.').pop()
 
@@ -76,6 +88,9 @@ const updateRuleWithRemote = (rule: Rule, remote: string) => {
       rule.content = replacePathWithRemote(rule.content, remote)
       break
     case 'merge':
+      rule.content = replacePathWithRemote(rule.content, remote)
+      break
+    case 'part':
       rule.content = replacePathWithRemote(rule.content, remote)
       break
   }


### PR DESCRIPTION
Version Bump to 0.1.5 and CLI Enhancements

This PR bumps the package version to 0.1.5 and introduces several improvements to the CLI functionality to enhance user experience.

## Overview of Changes:

1. **Version Bump**: Updated version from 0.1.4 to 0.1.5 in deno.json.

2. **Added New CLI Commands**:
   - `settings` command: Outputs the current settings, with an option to write to a file
   - `init` command: Initializes a new ghf config file with default configuration

3. **Improved Configuration File Handling**:
   - Added automatic config file discovery to find config files in various formats (.ts, .json, .js, .yaml, .yml)
   - Made the --config option optional by using file discovery as a fallback
   - Added a default configuration template for the init command

4. **Updated Rule Handling**:
   - Added support for 'part' type in the updateRuleWithRemote function

These changes improve the developer experience by providing more flexible configuration options and making it easier to get started with the tool through the init command and automatic configuration discovery.