### PR TITLE
feat(registry): added files in registry to integrate Deno, Lefthook, and automated setup in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -24,6 +24,10 @@ load(
 dotenv_watch()
 default_settings()
 
+local('deno run -A jsr:@michaelmass/ghf/cli type -o=.ghf.type.ts', quiet=True)
+local('deno run -A jsr:@michaelmass/ghf/cli apply', quiet=True)
+local('lefthook install', quiet=True)
+
 resource(
   name='Test',
   manual=True,

--- a/registry/ghf.default.json
+++ b/registry/ghf.default.json
@@ -17,6 +17,14 @@
     {
       "type": "preset",
       "name": "github-actions"
+    },
+    {
+      "type": "preset",
+      "name": "ci-deno"
+    },
+    {
+      "type": "preset",
+      "name": "lefthook"
     }
   ]
 }

--- a/registry/ghf.json
+++ b/registry/ghf.json
@@ -46,6 +46,25 @@
           "path": "ensure-checks-pass.yml"
         }
       }
+    ],
+    "ci-deno": [
+      {
+        "type": "merge",
+        "path": ".vscode/settings.json",
+        "mergeArrays": true,
+        "content": {
+          "path": "vscode-settings.json"
+        }
+      }
+    ],
+    "lefthook": [
+      {
+        "type": "file",
+        "path": "lefthook.yml",
+        "content": {
+          "path": "lefthook.yml"
+        }
+      }
     ]
   }
 }

--- a/registry/vscode-settings.json
+++ b/registry/vscode-settings.json
@@ -1,0 +1,1 @@
+{ "deno.enablePaths": ["ci"] }


### PR DESCRIPTION
Integration of Deno, Lefthook, and CI setup

This PR adds automation setup steps to our Tiltfile and extends our GHF configuration with Deno and Lefthook support.

## Overview of changes:

1. **Tiltfile Updates**:
   - Added automatic Deno type generation via `ghf` 
   - Added automatic GHF application on startup
   - Added Lefthook installation to ensure hooks are properly set up

2. **GHF Configuration**:
   - Added `ci-deno` preset to configure VSCode for Deno support
   - Added `lefthook` preset to implement git hooks
   - Added necessary configuration files:
     - Added new empty `lefthook.yml` file (to be populated with hooks)
     - Added VSCode settings to enable Deno in the CI path

These changes automate our development environment setup and ensure consistency across developer machines. The integration of Lefthook will help us enforce code quality standards through git hooks.

The Deno integration provides better tooling support for our TypeScript files and the VSCode settings ensure proper IDE integration.