### PR TITLE
chore(deps): update and reorganize imports across multiple files

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
 export { Command, EnumType } from 'jsr:@cliffy/command@1.0.0-rc.7'
-export { z } from 'npm:zod@3.25.62/v4'
-export { stringify as stringifyYaml, parse as parseYaml } from 'jsr:@std/yaml@0.221.0'
 export { exists } from 'jsr:@std/fs@1.0.18'
+export { parse as parseYaml, stringify as stringifyYaml } from 'jsr:@std/yaml@0.221.0'
+export { z } from 'npm:zod@3.25.62/v4'

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'https://deno.land/std@0.208.0/path/mod.ts'
+import { dirname } from 'jsr:@std/path'
 
 export async function fileExists(path: string): Promise<boolean> {
   try {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
-import * as esbuild from 'npm:esbuild@0.25.5'
 import { encodeBase64 } from 'jsr:@std/encoding@1.0.10/base64'
+import * as esbuild from 'npm:esbuild@0.25.5'
 import { parseYaml } from './deps.ts'
 
 function tseval(code: string) {

--- a/src/rules/init.ts
+++ b/src/rules/init.ts
@@ -1,7 +1,6 @@
 import { z } from '../deps.ts'
 import type { FileSystem } from '../filesystem.ts'
-import { loadContent } from '../schemas.ts'
-import { contentSchema } from '../schemas.ts'
+import { contentSchema, loadContent } from '../schemas.ts'
 
 export const ruleInitSchema = z.object({
   type: z.literal('init'),

--- a/src/rules/merge.ts
+++ b/src/rules/merge.ts
@@ -1,6 +1,5 @@
 import { merge } from 'npm:ts-deepmerge@7.0.3'
-import { z } from '../deps.ts'
-import { parseYaml, stringifyYaml } from '../deps.ts'
+import { parseYaml, stringifyYaml, z } from '../deps.ts'
 import type { FileSystem } from '../filesystem.ts'
 import { contentSchema, loadContent } from '../schemas.ts'
 


### PR DESCRIPTION
This pull request updates dependencies and improves code organization by reordering and consolidating imports. The changes focus on maintaining consistent import patterns throughout the codebase.

## Overview of changes:

1. Updated path import in `fs.ts`:
   - Replaced the direct Deno standard library import with the JSR registry format
   - Changed from `https://deno.land/std@0.208.0/path/mod.ts` to `jsr:@std/path`

2. Reorganized imports across multiple files:
   - Alphabetized imports in `deps.ts`
   - Consolidated related imports in `rules/init.ts` and `rules/merge.ts`
   - Reordered imports in `parse.ts` for better readability

These changes help maintain a more consistent codebase by standardizing import patterns and using the JSR registry format where appropriate. No functional changes were introduced - this is purely a code organization improvement.