### PR TITLE
chore(registry): remove stale Claude entries from .gitignore

### DIFF
--- a/registry/.gitignore
+++ b/registry/.gitignore
@@ -5,5 +5,3 @@ extension_tiltfile
 node_modules
 dist
 .ghf.type.ts
-.claude.db
-.claude.error


### PR DESCRIPTION
Remove stale Claude-related entries from the repository’s `.gitignore`.

**Overview**
- Updated `registry/.gitignore` to delete the `.claude.db` and `.claude.error` lines.
- These files are no longer generated by the project, and keeping them in the ignore list caused unnecessary clutter.
- The change simplifies the ignore configuration, aligning it with the current set of generated artifacts (`extension_tiltfile`, `node_modules`, `dist`, `.ghf.type.ts`).
- No functional code changes; only the ignore rules are affected, ensuring a cleaner repository state.