### PR TITLE
feat(ghf): switch to typescript-deno preset and add fetchText utility with refactored loading logic

### DIFF
--- a/.ghf.ts
+++ b/.ghf.ts
@@ -1,5 +1,5 @@
 import type { Config } from './.ghf.type'
 
 export default {
-  extends: ['https://michaelmass.github.io/ghf/ghf/default.json', 'https://michaelmass.github.io/ghf/ghf/typescript.json', 'https://michaelmass.github.io/ghf/ghf/mit.json'],
+  extends: ['https://michaelmass.github.io/ghf/ghf/default.json', 'https://michaelmass.github.io/ghf/ghf/typescript-deno.json', 'https://michaelmass.github.io/ghf/ghf/mit.json'],
 } satisfies Config

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from './deps.ts'
+import { fetchText } from './url.ts'
 
 export const contentSchema = z.union([
   z.object({
@@ -12,14 +13,13 @@ export const contentSchema = z.union([
 
 export type Content = z.infer<typeof contentSchema>
 
-export const loadContent = async (content: Content) => {
+export const loadContent = (content: Content) => {
   if (typeof content === 'string') {
     return content
   }
 
   if ('url' in content) {
-    const response = await fetch(content.url)
-    return response.text()
+    return fetchText(content.url)
   }
 
   return Deno.readTextFile(content.path)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,7 @@ import { fileExists } from './fs.ts'
 import { parse } from './parse.ts'
 import { type Rule, ruleSchema } from './rules/index.ts'
 import type { Content } from './schemas.ts'
-import { normalizeUrl } from './url.ts'
+import { fetchText, normalizeUrl } from './url.ts'
 
 export const settingsSchema = z.object({
   $schema: z.string().optional(),
@@ -30,11 +30,17 @@ export const loadSettings = async (path: string) => {
   const filepath = path === '' ? await findSettingsFile() : path
   const isRemote = filepath.startsWith('https://')
 
-  const content = isRemote ? await (await fetch(filepath)).text() : await Deno.readTextFile(filepath)
+  const content = isRemote ? await fetchText(filepath, 'settings') : await Deno.readTextFile(filepath)
 
-  const extension = filepath.split('.').pop()
+  const extension = filepath.split('.').pop() ?? ''
 
-  const data = await parse(content, extension ?? '')
+  let data: unknown
+
+  try {
+    data = await parse(content, extension)
+  } catch (cause) {
+    throw new Error(`Failed to parse settings from ${filepath} as ${extension}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause })
+  }
 
   const settings = settingsSchema.parse(data)
 
@@ -68,7 +74,7 @@ export const loadSettings = async (path: string) => {
   if (settings.extends?.length) {
     for (const extend of settings.extends) {
       const extendedSettings = await loadSettings(extend)
-      settings.presets = { ...(extendedSettings.presets ?? {}), ...(settings.presets ?? {}) }
+      settings.presets = { ...extendedSettings.presets, ...settings.presets }
       settings.rules?.unshift(...(extendedSettings.rules ?? []))
     }
   }

--- a/src/url.ts
+++ b/src/url.ts
@@ -3,3 +3,19 @@ export const normalizeUrl = (urlString: string) => {
   url.pathname = new URL(url.pathname, 'http://dummy').pathname
   return url.toString()
 }
+
+export const fetchText = async (url: string, label = 'content') => {
+  let response: Response
+
+  try {
+    response = await fetch(url)
+  } catch (cause) {
+    throw new Error(`Failed to fetch ${label} from ${url}: ${cause instanceof Error ? cause.message : String(cause)}`, { cause })
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${label} from ${url}: ${response.status} ${response.statusText}`)
+  }
+
+  return response.text()
+}


### PR DESCRIPTION
**Summary**
Updated the configuration to use the Deno‑specific TypeScript preset and refactored content loading and settings handling.

**Overview of changes**
- `.ghf.ts`: Switched the TypeScript preset from `typescript.json` to `typescript-deno.json`.
- `src/url.ts`: Added `fetchText` utility with robust error handling for fetching text resources.
- `src/schemas.ts`: Refactored `loadContent` to use the new `fetchText` helper and removed unnecessary async/await.
- `src/settings.ts`: Updated imports to include `fetchText`; refactored remote settings loading to use `fetchText`; added explicit handling for missing file extensions; added try/catch around parsing with a descriptive error; simplified preset merging logic.
- Minor import clean‑up and type safety improvements throughout the affected modules.

These changes improve reliability when fetching remote configuration files, simplify content loading, and ensure proper handling of parsing errors.